### PR TITLE
Update XMLReader-Encoding (only if needed)

### DIFF
--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -143,7 +143,7 @@ namespace ArchiSteamFarm {
 				return false;
 			}
 
-			using (XmlReader reader = XmlReader.Create(ConfigFile)) {
+			using (XmlReader reader = XmlReader.Create(new StreamReader(ConfigFile, Encoding.GetEncoding("Windows-1252"), true))) {
 				while (reader.Read()) {
 					if (reader.NodeType != XmlNodeType.Element) {
 						continue;


### PR DESCRIPTION
I found out Windows 10 is converting unusual quotes like ´ or ` to normal quotes like this '. To fix this I had to change the Encoding the XML-Reader is using and maybe if needed the encoding for xml-configs like <?xml version="1.0" encoding="ISO-8859-15"?>. This isn´t tested with *nix.