### PR TITLE
release semaphore on exit from startfarm

### DIFF
--- a/ArchiSteamFarm/CardsFarmer.cs
+++ b/ArchiSteamFarm/CardsFarmer.cs
@@ -112,13 +112,15 @@ namespace ArchiSteamFarm {
 				if (await Farm(appID).ConfigureAwait(false)) {
 					appIDs.Remove(appID);
 				} else {
-					return;
+                    Semaphore.Release();
+                    return;
 				}
 			}
 
 			Logging.LogGenericInfo(Bot.BotName, "Farming finished!");
 			await Bot.OnFarmingFinished().ConfigureAwait(false);
-		}
+            Semaphore.Release();
+        }
 
 		internal async Task StopFarming() {
 			await Semaphore.WaitAsync().ConfigureAwait(false);


### PR DESCRIPTION
Small bugfix of the issue when bots that finished farming were ignoring !stop command. This was because of semaphore not always released in StartFarm. 