### PR TITLE
added extended !status syntax

### DIFF
--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -277,11 +277,35 @@ namespace ArchiSteamFarm {
 			if (steamID == 0) {
 				return;
 			}
-
-			SendMessageToUser(steamID, "Currently " + Bots.Count + " bots are running");
+            if (CardsFarmer.CurrentGame > 0) {
+                SendMessageToUser(steamID, "Farming " + CardsFarmer.CurrentGame + " now");
+                SendMessageToUser(steamID, CardsFarmer.GamesLeft + " games left");
+                }
+            SendMessageToUser(steamID, "Currently " + Bots.Count + " bots are running");
 		}
 
-		private void ResponseStart(ulong steamID, string botNameToStart) {
+        private void ResponseStatus(ulong steamID, string botName)
+        {
+            if (steamID == 0 || string.IsNullOrEmpty(botName))
+            {
+                return;
+            }
+            Bot botToGet;
+            if (!Bots.TryGetValue(botName, out botToGet))
+            {
+                SendMessageToUser(steamID, "Running bot with this name not found!");
+                return;
+            }
+
+                if (botToGet.CardsFarmer.CurrentGame > 0)
+            {
+                SendMessageToUser(steamID, "Bot " + botName + " farming " + botToGet.CardsFarmer.CurrentGame +" now");
+                SendMessageToUser(steamID, "Bot " + botName + " has " + botToGet.CardsFarmer.GamesLeft + " games left");
+            }
+            SendMessageToUser(steamID, "Currently " + Bots.Count + " bots are running");
+        }
+
+        private void ResponseStart(ulong steamID, string botNameToStart) {
 			if (steamID == 0 || string.IsNullOrEmpty(botNameToStart)) {
 				return;
 			}
@@ -455,7 +479,10 @@ namespace ArchiSteamFarm {
 					case "!stop":
 						await ResponseStop(steamID, args[1]).ConfigureAwait(false);
 						break;
-				}
+                    case "!status":
+                        ResponseStatus(steamID, args[1]);
+                        break;
+                }
 			}
 		}
 

--- a/ArchiSteamFarm/CardsFarmer.cs
+++ b/ArchiSteamFarm/CardsFarmer.cs
@@ -29,6 +29,8 @@ using System.Threading.Tasks;
 
 namespace ArchiSteamFarm {
 	internal class CardsFarmer {
+        internal ulong CurrentGame { get; private set; } = 0;
+        internal int GamesLeft { get; private set; } = 0;
 		private const byte StatusCheckSleep = 5; // In minutes, how long to wait before checking the appID again
 
 		private readonly ManualResetEvent FarmResetEvent = new ManualResetEvent(false);
@@ -111,17 +113,23 @@ namespace ArchiSteamFarm {
 
 			// Start farming
 			while (appIDs.Count > 0) {
-				uint appID = appIDs[0];
+                GamesLeft = appIDs.Count;
+                uint appID = appIDs[0];
 				Logging.LogGenericInfo(Bot.BotName, "Now farming: " + appID);
-				if (await Farm(appID).ConfigureAwait(false)) {
+                CurrentGame = appID;
+                if (await Farm(appID).ConfigureAwait(false)) {
 					appIDs.Remove(appID);
 				} else {
-					NowFarming = false;
+                    GamesLeft = 0;
+                    CurrentGame = 0;
+                    NowFarming = false;
 					return;
 				}
 			}
 
-			NowFarming = false;
+            GamesLeft = 0;
+            CurrentGame = 0;
+            NowFarming = false;
 			Logging.LogGenericInfo(Bot.BotName, "Farming finished!");
 			await Bot.OnFarmingFinished().ConfigureAwait(false);
 		}
@@ -175,5 +183,5 @@ namespace ArchiSteamFarm {
 			Logging.LogGenericInfo(Bot.BotName, "Stopped farming: " + appID);
 			return success;
 		}
-	}
+    }
 }


### PR DESCRIPTION
Just a proposal for extending !status command functionality.
Added to answer appid that currently farming this bot and total remaining appid that bot going to farm.
Also, if !status followed by a bot config name - answers the above information about specified bot. This way, communicating with only one bot will be possible check status of all running bots one by one.