### PR TITLE
interprocess comunication via WCF

### DIFF
--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -85,6 +85,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArchiHandler.cs" />

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -95,7 +95,7 @@ namespace ArchiSteamFarm {
 		public delegate void RedeemEventHandler(object sender, RedeemEventArgs e);
 		
 		// Declare the event.
-		public event RedeemEventHandler RedeemEvent;
+		public event RedeemEventHandler RedeemEvent { add{} remove{} }
 
 		internal static bool IsValidCdKey(string key) {
 			if (string.IsNullOrEmpty(key)) {
@@ -475,8 +475,6 @@ namespace ArchiSteamFarm {
 			if (steamID == 0) {
 				return;
 			}
-
-			Bot bot;
 
 			if (string.IsNullOrEmpty(botName)) {
 				SendMessage(steamID,GetStatus(this.BotName));

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -35,6 +35,12 @@ using System.Threading.Tasks;
 using System.Xml;
 
 namespace ArchiSteamFarm {
+
+        public class RedeemEventArgs : EventArgs {
+                public RedeemEventArgs(string s) { Text = s; }
+                public string Text { get; private set; } // readonly
+        }
+
 	internal sealed class Bot {
 		private const ulong ArchiSCFarmGroup = 103582791440160998;
 		private const ushort CallbackSleep = 500; // In miliseconds

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -79,8 +79,19 @@ namespace ArchiSteamFarm {
 		internal bool ShutdownOnFarmingFinished { get; private set; } = false;
 		internal HashSet<uint> Blacklist { get; private set; } = new HashSet<uint>();
 		internal bool Statistics { get; private set; } = true;
+		internal bool doanswer { get; private set; } = true;
 
-		private static bool IsValidCdKey(string key) {
+		internal ConcurrentDictionary<string, Bot> GetBots (){
+			 return Bots;
+		}
+
+		// Declare the delegate (if using non-generic pattern).
+		public delegate void RedeemEventHandler(object sender, RedeemEventArgs e);
+		
+		// Declare the event.
+		public event RedeemEventHandler RedeemEvent;
+
+		internal static bool IsValidCdKey(string key) {
 			if (string.IsNullOrEmpty(key)) {
 				return false;
 			}
@@ -424,6 +435,36 @@ namespace ArchiSteamFarm {
 			}
 		}
 
+		internal static string GetStatus (string botName) {
+			Bot bot;
+			string result="";
+			if (string.IsNullOrEmpty(botName)) {
+				return "No bot name specified";
+			} else {
+				if (botName.Equals("all")) {
+					foreach (var curbot in Bots) {
+						if (curbot.Value.CardsFarmer.CurrentGamesFarming.Count == 0)
+							result+="Bot " + curbot.Key + " is not farming.\n";
+						else
+							result+="Bot " + curbot.Key + " is currently farming appIDs: " + string.Join(", ", 	curbot.Value.CardsFarmer.CurrentGamesFarming) + " and has a total of " + curbot.Value.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
+					}
+					result+="Currently " + Bots.Count + " bots are running.";
+					return result;
+				}
+
+				if (!Bots.TryGetValue(botName, out bot)) {
+					result+="Couldn't find any bot named " + botName + "!";
+					return result;
+				}
+			}
+
+			if (bot.CardsFarmer.CurrentGamesFarming.Count > 0) {
+				result+="Bot " + bot.BotName + " is currently farming appIDs: " + string.Join(", ", bot.CardsFarmer.CurrentGamesFarming) + " and has a total of " + bot.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
+			}
+			result+="Currently " + Bots.Count + " bots are running";
+			return result;
+		}
+
 		private void ResponseStatus(ulong steamID, string botName = null) {
 			if (steamID == 0) {
 				return;
@@ -432,18 +473,29 @@ namespace ArchiSteamFarm {
 			Bot bot;
 
 			if (string.IsNullOrEmpty(botName)) {
-				bot = this;
+				SendMessage(steamID,GetStatus(this.BotName));
+			} else {
+				SendMessage(steamID,GetStatus(botName));
+			}
+		}
+
+		internal static string Get2FA (string botName) {
+			Bot bot;
+
+			if (string.IsNullOrEmpty(botName)) {
+				return "Error";
 			} else {
 				if (!Bots.TryGetValue(botName, out bot)) {
-					SendMessage(steamID, "Couldn't find any bot named " + botName + "!");
-					return;
+					return "Couldn't find any bot named " + botName + "!";
 				}
 			}
 
-			if (bot.CardsFarmer.CurrentGamesFarming.Count > 0) {
-				SendMessage(steamID, "Bot " + bot.BotName + " is currently farming appIDs: " + string.Join(", ", bot.CardsFarmer.CurrentGamesFarming) + " and has a total of " + bot.CardsFarmer.GamesToFarm.Count + " games left to farm");
+			if (bot.SteamGuardAccount == null) {
+				return "That bot doesn't have ASF 2FA enabled!";
 			}
-			SendMessage(steamID, "Currently " + Bots.Count + " bots are running");
+
+			long timeLeft = 30 - TimeAligner.GetSteamTime() % 30;
+			return "2FA Token: " + bot.SteamGuardAccount.GenerateSteamGuardCode() + " (expires in " + timeLeft + " seconds)";
 		}
 
 		private void Response2FA(ulong steamID, string botName = null) {
@@ -469,6 +521,29 @@ namespace ArchiSteamFarm {
 
 			long timeLeft = 30 - TimeAligner.GetSteamTime() % 30;
 			SendMessage(steamID, "2FA Token: " + bot.SteamGuardAccount.GenerateSteamGuardCode() + " (expires in " + timeLeft + " seconds)");
+		}
+
+		internal static string Set2FAOff (string botName) {
+
+			Bot bot;
+
+			if (string.IsNullOrEmpty(botName)) {
+				return "Error";
+			} else {
+				if (!Bots.TryGetValue(botName, out bot)) {
+					return "Couldn't find any bot named " + botName + "!";
+				}
+			}
+
+			if (bot.SteamGuardAccount == null) {
+				return "That bot doesn't have ASF 2FA enabled!";
+			}
+
+			if (bot.DelinkMobileAuthenticator()) {
+				return "Done! Bot is no longer using ASF 2FA";
+			} else {
+				return "Something went wrong!";
+			}
 		}
 
 		private void Response2FAOff(ulong steamID, string botName = null) {
@@ -522,6 +597,19 @@ namespace ArchiSteamFarm {
 			SendMessage(SteamMasterID, "Status: " + purchaseResult + " | Items: " + string.Join("", items));
 		}
 
+		internal static string StartBot(string botName) {
+			if (Bots.ContainsKey(botName)) {
+				return  "That bot instance is already running!";
+			}
+
+			new Bot(botName);
+			if (Bots.ContainsKey(botName)) {
+				return "Done!";
+			} else {
+				return "That bot instance failed to start, make sure that XML config exists and bot is active!";
+			}
+
+		}
 		private void ResponseStart(ulong steamID, string botName) {
 			if (steamID == 0 || string.IsNullOrEmpty(botName)) {
 				return;
@@ -539,6 +627,24 @@ namespace ArchiSteamFarm {
 				SendMessage(steamID, "That bot instance failed to start, make sure that XML config exists and bot is active!");
 			}
 		}
+		internal static string StopBot(string botName) {
+			if (string.IsNullOrEmpty(botName)) {
+				return "Error";
+			}
+			Bot bot;
+			if (!Bots.TryGetValue(botName, out bot)) { 
+				return "That bot instance is already inactive!";
+			}
+
+			Task<bool> task =  bot.Shutdown();
+			task.Wait();
+			if (task.Result) {
+				return "Done!";
+			} else {
+				return "That bot instance failed to shutdown!";
+			}
+
+		}
 
 		private async Task ResponseStop(ulong steamID, string botName) {
 			if (steamID == 0 || string.IsNullOrEmpty(botName)) {
@@ -555,6 +661,43 @@ namespace ArchiSteamFarm {
 			} else {
 				SendMessage(steamID, "That bot instance failed to shutdown!");
 			}
+		}
+
+		public static Task<string> PurchaseResultAsync(Bot bot, string gamekey) {
+			var tcs = new TaskCompletionSource<string>();
+			bot.doanswer = false;
+			bot.RedeemEvent += (s, e) =>
+			{
+				bot.doanswer = true;
+				tcs.TrySetResult(e.Text);
+			};
+			bot.ArchiHandler.RedeemKey(gamekey);
+			return tcs.Task;
+		}
+
+		internal static string ActivateKey(string botName,string gamekey) {
+			Bot bot;
+ 			if (!Bots.TryGetValue(botName, out bot)) {
+				return "Bot is inactive and can't activate keys";
+			}
+			Task<string> task = PurchaseResultAsync(bot, gamekey);
+			task.Wait();
+			return task.Result;
+
+		}
+
+		private async Task ResponseMultiActivate(ulong steamID, string[] gamekeys) {
+			string results="";
+			int i = 0;
+			foreach (var curbot in Bots) {
+				results+=curbot.Key+ " answer: " + await PurchaseResultAsync(curbot.Value, gamekeys[i].Trim())+"\n";
+				i++;
+				if (gamekeys.Length <= i)
+					break;
+			}
+
+			SendMessage(steamID, results);
+
 		}
 
 		private async Task HandleMessage(ulong steamID, string message) {


### PR DESCRIPTION
My attempt to implement interprocess communication.
if ASF started without command-line parameters - it starts as usual, and listens to the incoming commands.
if ASF started with command-line parameters - it attempts to send this commands to the main ASF process.
supported commands:
`status` or `status all` - status of all running bots.
`status <BOT>`
`stop <BOT>` 
`start <BOT>`
`redeem <BOT> <KEY>`
`exit`
`restart` - I know it's "hidden", but I added a call to it too)
`2fa`
`2faoff`

I know my code is crappy and you probably wouldn't want to merge it, but maybe it would serve as an inspiration to you.

side notes:
- I tried named pipes - it does not seem to work under mono, so I switched to WCF.
- when setting a socket for WCF port needs to be >1024, otherwise application would only work if started from root account under mono.