### PR TITLE
interprocess communications via WCF

### DIFF
--- a/ArchiSteamFarm/ArchiSteamFarm.csproj
+++ b/ArchiSteamFarm/ArchiSteamFarm.csproj
@@ -85,6 +85,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ArchiHandler.cs" />

--- a/ArchiSteamFarm/Program.cs
+++ b/ArchiSteamFarm/Program.cs
@@ -28,8 +28,57 @@ using System.IO;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using System.ServiceModel;
 
 namespace ArchiSteamFarm {
+	[ServiceContract]
+	public interface IWCFconnect {
+		[OperationContract]
+		string SendText(string text);
+	}
+
+	public class WCFconnect : IWCFconnect {
+		public string SendText(string text) {
+			if (!text.Contains(" ")) {
+				switch (text) {
+#pragma warning disable CS4014
+                    case "exit":
+						Bot.ShutdownAllBots();
+						return "Shutdown planned"; //return without waiting
+					case "restart":
+						Program.Restart();
+						return "Restart planned"; //return without waiting
+#pragma warning restore CS4014
+                    case "status":
+						return Bot.GetStatus("all");
+				}
+			} else {
+				string[] args = text.Split(' ');
+				switch (args[0]) {
+					case "2fa":
+						return Bot.Get2FA(args[1]);
+					case "2faoff":
+						return Bot.Set2FAOff(args[1]);
+					case "redeem":
+						if (args.Length<3) {
+							return "Error";
+						} else {
+							Task<string> task=Bot.RedeemKey(args[2],args[1]);
+							task.Wait();
+							return task.Result;
+						}
+					case "start":
+						return Bot.StartBot(args[1]);
+					case "stop":
+						return Bot.StopBot(args[1]);
+					case "status":
+						return Bot.GetStatus(args[1]);
+				}
+			}
+			return "Error";
+		}
+	}
+
 	internal static class Program {
 		internal enum EUserInputType {
 			Login,
@@ -54,6 +103,8 @@ namespace ArchiSteamFarm {
 		private static readonly string ExecutableDirectory = Path.GetDirectoryName(ExecutableFile);
 
 		internal static readonly string Version = Assembly.GetName().Version.ToString();
+
+		private static ServiceHost host = null;
 
 		internal static bool ConsoleIsBusy { get; private set; } = false;
 
@@ -144,8 +195,10 @@ namespace ArchiSteamFarm {
 		internal static async void OnBotShutdown() {
 			if (Bot.GetRunningBotsCount() == 0) {
 				Logging.LogGenericInfo("Main", "No bots are running, exiting");
+				host.Close();
 				await Utilities.SleepAsync(5000).ConfigureAwait(false); // This might be the only message user gets, consider giving him some time
 				ShutdownResetEvent.Set();
+			
 			}
 		}
 
@@ -155,47 +208,75 @@ namespace ArchiSteamFarm {
 		}
 
 		private static void Main(string[] args) {
-			Directory.SetCurrentDirectory(ExecutableDirectory);
-			InitServices();
+			if (args.Length > 0) {
+				//client, send the message to server				
+				IWCFconnect con = null;
+				try {
+					string message=args[0];
+					for (int j=1;j<args.Length;j++) {
+						message+=" "+args[j];
+					}
+					Uri tcpUri = new Uri(string.Format("http://{0}:{1}/ASFService", "localhost", "1050"));
+					EndpointAddress address = new EndpointAddress(tcpUri, EndpointIdentity.CreateSpnIdentity("Server"));
+					ChannelFactory<IWCFconnect> factory = new ChannelFactory<IWCFconnect>(new BasicHttpBinding(), address);
+					con = factory.CreateChannel();
+					Console.WriteLine(con.SendText(message));
+				}
+				catch (Exception e) {	//not the best idea really
+					Console.WriteLine("ERROR: {0}", e.Message);
+				}
+			} else {
+				//server, main routine
+				try {
+					host = new ServiceHost(typeof(WCFconnect), new Uri("http://localhost:1050/ASFService"));
+					host.AddServiceEndpoint(typeof(IWCFconnect), new BasicHttpBinding(), "");
+					host.Open();
+				} catch (Exception e) {
+					Logging.LogGenericInfo("Main", "Error: "+e.Message);
+				}
 
-			// Allow loading configs from source tree if it's a debug build
-			if (Debugging.IsDebugBuild) {
+				Directory.SetCurrentDirectory(ExecutableDirectory);
+				InitServices();
 
-				// Common structure is bin/(x64/)Debug/ArchiSteamFarm.exe, so we allow up to 4 directories up
-				for (var i = 0; i < 4; i++) {
-					Directory.SetCurrentDirectory("..");
-					if (Directory.Exists(ConfigDirectory)) {
-						break;
+				// Allow loading configs from source tree if it's a debug build
+				if (Debugging.IsDebugBuild) {
+
+					// Common structure is bin/(x64/)Debug/ArchiSteamFarm.exe, so we allow up to 4 directories up
+					for (var i = 0; i < 4; i++) {
+						Directory.SetCurrentDirectory("..");
+						if (Directory.Exists(ConfigDirectory)) {
+							break;
+						}
+					}
+
+					// If config directory doesn't exist after our adjustment, abort all of that
+					if (!Directory.Exists(ConfigDirectory)) {
+						Directory.SetCurrentDirectory(ExecutableDirectory);
 					}
 				}
 
-				// If config directory doesn't exist after our adjustment, abort all of that
+				Logging.LogGenericInfo("Main", "Archi's Steam Farm, version " + Version);
+				Task.Run(async () => await CheckForUpdate().ConfigureAwait(false)).Wait();
+
 				if (!Directory.Exists(ConfigDirectory)) {
-					Directory.SetCurrentDirectory(ExecutableDirectory);
+					Logging.LogGenericError("Main", "Config directory doesn't exist!");
+					Thread.Sleep(5000);
+					Task.Run(async () => await Exit(1).ConfigureAwait(false)).Wait();
 				}
-			}
 
-			Logging.LogGenericInfo("Main", "Archi's Steam Farm, version " + Version);
-			Task.Run(async () => await CheckForUpdate().ConfigureAwait(false)).Wait();
-
-			if (!Directory.Exists(ConfigDirectory)) {
-				Logging.LogGenericError("Main", "Config directory doesn't exist!");
-				Thread.Sleep(5000);
-				Task.Run(async () => await Exit(1).ConfigureAwait(false)).Wait();
-			}
-
-			foreach (var configFile in Directory.EnumerateFiles(ConfigDirectory, "*.xml")) {
-				string botName = Path.GetFileNameWithoutExtension(configFile);
-				Bot bot = new Bot(botName);
-				if (!bot.Enabled) {
-					Logging.LogGenericInfo(botName, "Not starting this instance because it's disabled in config file");
+				foreach (var configFile in Directory.EnumerateFiles(ConfigDirectory, "*.xml")) {
+					string botName = Path.GetFileNameWithoutExtension(configFile);
+					Bot bot = new Bot(botName);
+					if (!bot.Enabled) {
+						Logging.LogGenericInfo(botName, "Not starting this instance because it's disabled in config file");
+					}
 				}
+
+				// Check if we got any bots running
+				OnBotShutdown();
+
+				ShutdownResetEvent.WaitOne();
 			}
-
-			// Check if we got any bots running
-			OnBotShutdown();
-
-			ShutdownResetEvent.WaitOne();
 		}
 	}
 }


### PR DESCRIPTION
(one more) attempt to implement interprocess communications. Should cover #55 and #53.
Also, this pull request contains some parts of the [previous one](https://github.com/JustArchi/ArchiSteamFarm/pull/20), except of multiple keys redeeming (I wanted this to be as plain as possible, so any side-improvements was excluded). If this would satisfy you I would provide multi-redeeming in separate pull-request.
if ASF started without command-line parameters - it starts as usual, and listens to the incoming commands.
if ASF started with command-line parameters - it attempts to send this commands to the main ASF process.
supported commands:
`status` or `status all` - status of all running bots.
`status <BOT>`
`stop <BOT>`
`start <BOT>`
`redeem <BOT> <KEY>`
`exit`
`restart` - I know it's "hidden", but I added a call to it too)
`2fa`
`2faoff`

I know my code is crappy and you probably wouldn't want to merge it, but maybe it would serve as an inspiration to you.

side notes:

- I tried named pipes - it does not seem to work under mono, so I switched to WCF.
- when setting a socket for WCF port needs to be >1024, otherwise application would only work if started from root account under mono.
- I didn't tested `2fa` and `2faoff` commands yet. Have to time to connect bots to 2fa system. Would do this soon.

