### PR TITLE
command !status all to bring them all

### DIFF
--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -443,24 +443,23 @@ namespace ArchiSteamFarm {
 			string result="";
 			if (string.IsNullOrEmpty(botName)) {
 				return null;
-			} else {
-				if (botName.Equals("all")) {
-					foreach (var curbot in Bots) {
-						if (curbot.Value.CardsFarmer.CurrentGamesFarming.Count == 0)
-							result+="Bot " + curbot.Key + " is not farming.\n";
-						else
-							result+="Bot " + curbot.Key + " is currently farming appIDs: " + string.Join(", ", 	curbot.Value.CardsFarmer.CurrentGamesFarming) + " and has a total of " + curbot.Value.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
-					}
-					result+="Currently " + Bots.Count + " bots are running.";
-					return result;
+			}
+			if (botName.Equals("all")) {
+				foreach (var curbot in Bots) {
+					if (curbot.Value.CardsFarmer.CurrentGamesFarming.Count == 0)
+						result+="Bot " + curbot.Key + " is not farming.\n";
+					else
+						result+="Bot " + curbot.Key + " is currently farming appIDs: " + string.Join(", ", 	curbot.Value.CardsFarmer.CurrentGamesFarming) + " and has a total of " + curbot.Value.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
+				}
+				result+="Currently " + Bots.Count + " bots are running.";
+				return result;
 			}
 
 			if (!Bots.TryGetValue(botName, out bot)) {
 					result+="Couldn't find any bot named " + botName + "!";
 					return result;
-				}
 			}
-
+			
 			if (bot.CardsFarmer.CurrentGamesFarming.Count > 0) {
 				result+="Bot " + bot.BotName + " is currently farming appIDs: " + string.Join(", ", bot.CardsFarmer.CurrentGamesFarming) + " and has a total of " + bot.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
 			}

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -444,26 +444,28 @@ namespace ArchiSteamFarm {
 			if (string.IsNullOrEmpty(botName)) {
 				return null;
 			}
-			if (botName.Equals("all")) {
-				foreach (var curbot in Bots) {
-					if (curbot.Value.CardsFarmer.CurrentGamesFarming.Count == 0)
-						result+="Bot " + curbot.Key + " is not farming.\n";
-					else
-						result+="Bot " + curbot.Key + " is currently farming appIDs: " + string.Join(", ", 	curbot.Value.CardsFarmer.CurrentGamesFarming) + " and has a total of " + curbot.Value.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
-				}
-				result+="Currently " + Bots.Count + " bots are running.";
-				return result;
-			}
 
 			if (!Bots.TryGetValue(botName, out bot)) {
-					result+="Couldn't find any bot named " + botName + "!";
-					return result;
+				result+="Couldn't find any bot named " + botName + "!";
+				return result;
 			}
 			
 			if (bot.CardsFarmer.CurrentGamesFarming.Count > 0) {
 				result+="Bot " + bot.BotName + " is currently farming appIDs: " + string.Join(", ", bot.CardsFarmer.CurrentGamesFarming) + " and has a total of " + bot.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
 			}
 			result+="Currently " + Bots.Count + " bots are running";
+			return result;
+		}
+
+		internal static string ResponseStatusAll() {
+			string result = "";
+			foreach (var curbot in Bots) {
+				if (curbot.Value.CardsFarmer.CurrentGamesFarming.Count == 0)
+					result += "Bot " + curbot.Key + " is not farming.\n";
+				else
+					result += "Bot " + curbot.Key + " is currently farming appIDs: " + string.Join(", ", curbot.Value.CardsFarmer.CurrentGamesFarming) + " and has a total of " + curbot.Value.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
+			}
+			result += "Currently " + Bots.Count + " bots are running.";
 			return result;
 		}
 
@@ -591,6 +593,8 @@ namespace ArchiSteamFarm {
 						return "Done";
 					case "!status":
 						return ResponseStatus(BotName);
+					case "!statusall":
+						return ResponseStatusAll();
 					case "!stop":
 						return await ResponseStop(BotName).ConfigureAwait(false);
 					default:

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -33,6 +33,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Xml;
+using System.Text;
 
 namespace ArchiSteamFarm {
 	internal sealed class Bot {
@@ -440,33 +441,29 @@ namespace ArchiSteamFarm {
 
 		internal static string ResponseStatus(string botName) {
 			Bot bot;
-			string result="";
 			if (string.IsNullOrEmpty(botName)) {
 				return null;
 			}
 
 			if (!Bots.TryGetValue(botName, out bot)) {
-				result+="Couldn't find any bot named " + botName + "!";
-				return result;
+				return "Couldn't find any bot named " + botName + "!"; ;
 			}
 			
 			if (bot.CardsFarmer.CurrentGamesFarming.Count > 0) {
-				result+="Bot " + bot.BotName + " is currently farming appIDs: " + string.Join(", ", bot.CardsFarmer.CurrentGamesFarming) + " and has a total of " + bot.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
+				return "Bot " + bot.BotName + " is currently farming appIDs: " + string.Join(", ", bot.CardsFarmer.CurrentGamesFarming) + " and has a total of " + bot.CardsFarmer.GamesToFarm.Count + " games left to farm.";
+			} else {
+				return "Bot " + bot.BotName + " is not farming.";
+
 			}
-			result+="Currently " + Bots.Count + " bots are running";
-			return result;
 		}
 
 		internal static string ResponseStatusAll() {
-			string result = "";
+			StringBuilder result = new StringBuilder();
 			foreach (var curbot in Bots) {
-				if (curbot.Value.CardsFarmer.CurrentGamesFarming.Count == 0)
-					result += "Bot " + curbot.Key + " is not farming.\n";
-				else
-					result += "Bot " + curbot.Key + " is currently farming appIDs: " + string.Join(", ", curbot.Value.CardsFarmer.CurrentGamesFarming) + " and has a total of " + curbot.Value.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
+				result.Append(ResponseStatus(curbot.Key)+Environment.NewLine);
 			}
-			result += "Currently " + Bots.Count + " bots are running.";
-			return result;
+			result.Append("Currently " + Bots.Count + " bots are running.");
+			return result.ToString();
 		}
 
 		internal static string Response2FA(string botName) {

--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -439,16 +439,33 @@ namespace ArchiSteamFarm {
 		}
 
 		internal static string ResponseStatus(string botName) {
+			Bot bot;
+			string result="";
 			if (string.IsNullOrEmpty(botName)) {
 				return null;
+			} else {
+				if (botName.Equals("all")) {
+					foreach (var curbot in Bots) {
+						if (curbot.Value.CardsFarmer.CurrentGamesFarming.Count == 0)
+							result+="Bot " + curbot.Key + " is not farming.\n";
+						else
+							result+="Bot " + curbot.Key + " is currently farming appIDs: " + string.Join(", ", 	curbot.Value.CardsFarmer.CurrentGamesFarming) + " and has a total of " + curbot.Value.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
+					}
+					result+="Currently " + Bots.Count + " bots are running.";
+					return result;
 			}
 
-			Bot bot;
 			if (!Bots.TryGetValue(botName, out bot)) {
-				return "Couldn't find any bot named " + botName + "!";
+					result+="Couldn't find any bot named " + botName + "!";
+					return result;
+				}
 			}
 
-			return "Bot " + bot.BotName + " is currently farming appIDs: " + string.Join(", ", bot.CardsFarmer.CurrentGamesFarming) + " and has a total of " + bot.CardsFarmer.GamesToFarm.Count + " games left to farm";
+			if (bot.CardsFarmer.CurrentGamesFarming.Count > 0) {
+				result+="Bot " + bot.BotName + " is currently farming appIDs: " + string.Join(", ", bot.CardsFarmer.CurrentGamesFarming) + " and has a total of " + bot.CardsFarmer.GamesToFarm.Count + " games left to farm.\n";
+			}
+			result+="Currently " + Bots.Count + " bots are running";
+			return result;
 		}
 
 		internal static string Response2FA(string botName) {

--- a/ArchiSteamFarm/WCF.cs
+++ b/ArchiSteamFarm/WCF.cs
@@ -84,6 +84,7 @@ namespace ArchiSteamFarm {
 			Logging.LogGenericInfo("WCF", "Received command: \"" + input + "\"");
 
 			string command = '!' + input;
+			if (command.Equals("!status")) command+=" all"; //show status off all bots if no bot specified
 			string output = bot.HandleMessage(command).Result; // TODO: This should be asynchronous
 
 			Logging.LogGenericInfo("WCF", "Answered to command: \"" + input + "\" with: \"" + output + "\"");

--- a/ArchiSteamFarm/WCF.cs
+++ b/ArchiSteamFarm/WCF.cs
@@ -84,7 +84,6 @@ namespace ArchiSteamFarm {
 			Logging.LogGenericInfo("WCF", "Received command: \"" + input + "\"");
 
 			string command = '!' + input;
-			if (command.Equals("!status")) command+=" all"; //show status off all bots if no bot specified
 			string output = bot.HandleMessage(command).Result; // TODO: This should be asynchronous
 
 			Logging.LogGenericInfo("WCF", "Answered to command: \"" + input + "\" with: \"" + output + "\"");


### PR DESCRIPTION
Command `!status all` returns status of all running bots. Made it separate command instead of just `!status` because it can produce huge output on large bot farms.
For wcf I decided just `status` would be enough, because this command sent through wcf would have no much sense anyway without specified botname (who need the status of first bot?).