### PR TITLE
Distribute keys among bots

### DIFF
--- a/ArchiSteamFarm/config/example.xml
+++ b/ArchiSteamFarm/config/example.xml
@@ -97,6 +97,14 @@
 	<!-- Therefore, be careful when it comes to multiple keys activations, this option is supposed to help you, not make you lazy -->
 	<ForwardKeysToOtherBots type="bool" value="false"/>
 
+	<!-- This switch defines bot behavior on getting multiple keys -->
+	<!-- When "false" will try to redeem all keys to itself, when "true" keys will be distributed on "one bot, one key" basis -->
+	<!-- The above parameter "ForwardKeysToOtherBots" affects this behavior -->
+	<!-- When "ForwardKeysToOtherBots"="true", bot will try redeeming "AlreadyOwned", "BaseGameRequired", "OnCooldown" and "RegionLocked" keys on other available accounts -->
+	<!-- If "ForwardKeysToOtherBots"="false" bot just keep keys unused in this case. -->
+	<!-- By default this option is disabled, as not everyone might want to redeem keys on other configured accounts -->
+	<DistributeKeys type="bool" value="false"/>
+
 	<!-- This switch defines if bot should disconnect once farming is finished -->
 	<!-- Keep in mind that when no bots are active, ASF will shutdown as well -->
 	<!-- You may want to disconnect the bot after he's done, if that's the case, set below to "true" -->


### PR DESCRIPTION
That's what we were talking about in #76.
I added a new parameter `DistributeKeys`, `false` by default. And when it's `false` there should be no difference from now. When `true` - it would distribute multiple keys among bots, taking into consideration `ForwardKeysToOtherBots` parameter also. Here is an illustration on how it works in different situations, assuming we have 4 bots and three keys are sent to the first bot:

`ForwardKeysToOtherBots=false` & `Distribute=false`
>\<botname1> Key: 11111-11111-11111 | Status: OnCooldown | Items: 
\<botname1> Key: 22222-22222-22222 | Status: OnCooldown | Items: 
\<botname1> Key: 33333-33333-33333 | Status: OnCooldown | Items: 

`ForwardKeysToOtherBots=true` & `Distribute=false`
>\<botname1> Key: 11111-11111-11111 | Status: OnCooldown | Items: 
\<botname2> Key: 11111-11111-11111 | Status: OK | Items: [71655, Blood of Old]
\<botname1> Key: 22222-22222-22222 | Status: OnCooldown | Items: 
\<botname2> Key: 22222-22222-22222 | Status: AlreadyOwned | Items: [71655, Blood of Old]
\<botname3> Key: 22222-22222-22222 | Status: AlreadyOwned | Items: [71655, Blood of Old]
\<botname4> Key: 22222-22222-22222 | Status: AlreadyOwned | Items: [71655, Blood of Old]
\<botname1> Key: 33333-33333-33333 | Status: OnCooldown | Items: 
\<botname2> Key: 33333-33333-33333 | Status: AlreadyOwned | Items: [71655, Blood of Old]
\<botname3> Key: 33333-33333-33333 | Status: AlreadyOwned | Items: [71655, Blood of Old]
\<botname4> Key: 33333-33333-33333 | Status: AlreadyOwned | Items: [71655, Blood of Old]`

`ForwardKeysToOtherBots=false` & `Distribute=true` - simple distribution, disregard of returned status
>\<botname1> Key: 11111-11111-11111 | Status: AlreadyOwned | Items: [71655, Blood of Old]
\<botname2> Key: 22222-22222-22222 | Status: AlreadyOwned | Items: [71655, Blood of Old]
\<botname3> Key: 33333-33333-33333 | Status: AlreadyOwned | Items: [71655, Blood of Old]

`ForwardKeysToOtherBots=true` & `Distribute=true` - "smart" distribution.
>\<botname1> Key: 11111-11111-11111 | Status: AlreadyOwned | Items: [71655, Blood of Old]
\<botname2> Key: 11111-11111-11111 | Status: AlreadyOwned | Items: [71655, Blood of Old]
\<botname3> Key: 11111-11111-11111 | Status: AlreadyOwned | Items: [71655, Blood of Old]
\<botname4> Key: 11111-11111-11111 | Status: AlreadyOwned | Items: [71655, Blood of Old]

It's not shown above, but with "smart" distribution if redeeming a key returns "InvalidKey" or "DuplicatedKey" status, it would try to redeem **next** key on the **same** bot.