### PR TITLE
Commands to accept all pending 2fa confirmation requests

### DIFF
--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -338,6 +338,10 @@ namespace ArchiSteamFarm {
 						return ResponseStatus();
 					case "!statusall":
 						return ResponseStatusAll();
+                                        case "!confirm":
+						return await ResponseConfirm(BotName);
+                                        case "!confirmall":
+						return await ResponseConfirmAll();
 					case "!stop":
 						return ResponseStop();
 					case "!loot":
@@ -378,6 +382,8 @@ namespace ArchiSteamFarm {
 						return ResponseStop(args[1]);
 					case "!status":
 						return ResponseStatus(args[1]);
+					case "!confirm":
+						return await ResponseConfirm(args[1]);
 					case "!loot":
 						return await ResponseSendTrade(args[1]).ConfigureAwait(false);
 					default:
@@ -491,6 +497,29 @@ namespace ArchiSteamFarm {
 			}
 
 			return await bot.ResponseSendTrade().ConfigureAwait(false);
+		}
+
+		private static async Task<string> ResponseConfirm(string botName) {
+			if (string.IsNullOrEmpty(botName)) {
+				return null;
+			}
+
+			Bot bot;
+			if (!Bots.TryGetValue(botName, out bot)) {
+				return "Couldn't find any bot named " + botName + "!";
+			}
+
+			await bot.AcceptAllConfirmations().ConfigureAwait(false);
+			return "Done!";
+		}
+
+		private static async Task<string> ResponseConfirmAll() {
+
+			foreach (Bot bot in Bots.Values) {
+				await bot.AcceptAllConfirmations().ConfigureAwait(false);
+			}
+
+			return "Done!";
 		}
 
 		private string Response2FA() {


### PR DESCRIPTION
It mainly useful if you have main account connected to ASF with 2fa on. With recent steam changes setting every item to sell on trade market needs confirmation in 2fa authenticator, so I think it's a good thing to have a command to confirm them all in one click.
Another option is to have periodic check for pending 2fa confirmation, but I don't like this idea. If you think differently, or simply don't want this functionality in ASF - simply close this pull request, no hard feelings, I understand that it's not what majority of users would use.

I added `!confirm`, `!confirm <BOT>` and `!confirmall` commands, to accept all 2fa confirmation request on current bot, named bot and all running bots accordingly.