### PR TITLE
preventing the creation of the default event source

### DIFF
--- a/ArchiSteamFarm/ArchiServiceInstaller.cs
+++ b/ArchiSteamFarm/ArchiServiceInstaller.cs
@@ -46,6 +46,8 @@ namespace ArchiSteamFarm {
 			// System account, requires admin privilege to install
 			serviceProcessInstaller.Account = ServiceAccount.LocalSystem;
 
+			serviceInstaller.Installers.Clear();
+
 			EventLogInstaller logInstaller = new EventLogInstaller {
 				Log = SharedInfo.EventLog,
 				Source = SharedInfo.EventLogSource


### PR DESCRIPTION
I forgot to remove the default event log source created when a service is installed which registers the service name as a log source in the application log