### PR TITLE
Add an option to switch WCF metadata publishing

### DIFF
--- a/ArchiSteamFarm/GlobalConfig.cs
+++ b/ArchiSteamFarm/GlobalConfig.cs
@@ -106,9 +106,6 @@ namespace ArchiSteamFarm {
 		internal readonly ushort WCFPort = DefaultWCFPort;
 
         [JsonProperty(Required = Required.DisallowNull)]
-        internal readonly bool WCFPublishMetadata = false;
-
-        [JsonProperty(Required = Required.DisallowNull)]
 		internal readonly bool Statistics = true;
 
 		[JsonProperty(Required = Required.DisallowNull)]

--- a/ArchiSteamFarm/GlobalConfig.cs
+++ b/ArchiSteamFarm/GlobalConfig.cs
@@ -105,7 +105,10 @@ namespace ArchiSteamFarm {
 		[JsonProperty(Required = Required.DisallowNull)]
 		internal readonly ushort WCFPort = DefaultWCFPort;
 
-		[JsonProperty(Required = Required.DisallowNull)]
+        [JsonProperty(Required = Required.DisallowNull)]
+        internal readonly bool WCFPublishMetadata = false;
+
+        [JsonProperty(Required = Required.DisallowNull)]
 		internal readonly bool Statistics = true;
 
 		[JsonProperty(Required = Required.DisallowNull)]

--- a/ArchiSteamFarm/WCF.cs
+++ b/ArchiSteamFarm/WCF.cs
@@ -26,6 +26,7 @@ using System;
 using System.Linq;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
 
 namespace ArchiSteamFarm {
 	[ServiceContract]
@@ -87,8 +88,17 @@ namespace ArchiSteamFarm {
 			}
 
 			Logging.LogGenericInfo("Starting WCF server...");
-			ServiceHost = new ServiceHost(typeof(WCF));
-			ServiceHost.AddServiceEndpoint(typeof(IWCF), new BasicHttpBinding(), URL);
+			ServiceHost = new ServiceHost(typeof(WCF), new Uri(URL));
+		    if (Program.GlobalConfig.WCFPublishMetadata)
+		    {
+		        ServiceHost.Description.Behaviors.Add(new ServiceMetadataBehavior
+		        {
+		            HttpGetEnabled = true
+		        });
+		        ServiceHost.AddServiceEndpoint(ServiceMetadataBehavior.MexContractName,
+		            MetadataExchangeBindings.CreateMexHttpBinding(), "mex");
+		    }
+			ServiceHost.AddServiceEndpoint(typeof(IWCF), new BasicHttpBinding(), string.Empty);
 
 			try {
 				ServiceHost.Open();

--- a/ArchiSteamFarm/WCF.cs
+++ b/ArchiSteamFarm/WCF.cs
@@ -89,15 +89,12 @@ namespace ArchiSteamFarm {
 
 			Logging.LogGenericInfo("Starting WCF server...");
 			ServiceHost = new ServiceHost(typeof(WCF), new Uri(URL));
-		    if (Program.GlobalConfig.WCFPublishMetadata)
+		    ServiceHost.Description.Behaviors.Add(new ServiceMetadataBehavior
 		    {
-		        ServiceHost.Description.Behaviors.Add(new ServiceMetadataBehavior
-		        {
-		            HttpGetEnabled = true
-		        });
-		        ServiceHost.AddServiceEndpoint(ServiceMetadataBehavior.MexContractName,
-		            MetadataExchangeBindings.CreateMexHttpBinding(), "mex");
-		    }
+		        HttpGetEnabled = true
+		    });
+		    ServiceHost.AddServiceEndpoint(ServiceMetadataBehavior.MexContractName,
+		        MetadataExchangeBindings.CreateMexHttpBinding(), "mex");
 			ServiceHost.AddServiceEndpoint(typeof(IWCF), new BasicHttpBinding(), string.Empty);
 
 			try {


### PR DESCRIPTION
Make it easier to use SvcUtil.exe to generate client codes.