### PR TITLE
Added SteamOperatorID property

### DIFF
--- a/ArchiSteamFarm/Bot.cs
+++ b/ArchiSteamFarm/Bot.cs
@@ -1070,6 +1070,15 @@ namespace ArchiSteamFarm {
 			return false;
 		}
 
+		private bool IsOperator(ulong steamID) {
+			if (steamID != 0) {
+				return (steamID == BotConfig.SteamOperatorID) || IsMaster(steamID);
+			}
+
+			ArchiLogger.LogNullError(nameof(steamID));
+			return false;
+		}
+
 		private bool IsMasterClanID(ulong steamID) {
 			if (steamID != 0) {
 				return steamID == BotConfig.SteamMasterClanID;
@@ -1382,7 +1391,7 @@ namespace ArchiSteamFarm {
 						ArchiHandler.AcceptClanInvite(friend.SteamID, false);
 					}
 				} else {
-					if (IsMaster(friend.SteamID)) {
+					if (IsOperator(friend.SteamID)) {
 						SteamFriends.AddFriend(friend.SteamID);
 					} else if (BotConfig.IsBotAccount) {
 						SteamFriends.RemoveFriend(friend.SteamID);
@@ -1890,7 +1899,7 @@ namespace ArchiSteamFarm {
 				return null;
 			}
 
-			if (!IsMaster(steamID)) {
+			if (!IsOperator(steamID)) {
 				return null;
 			}
 
@@ -1935,7 +1944,7 @@ namespace ArchiSteamFarm {
 				return null;
 			}
 
-			if (!IsMaster(steamID)) {
+			if (!IsOperator(steamID)) {
 				return null;
 			}
 
@@ -2087,7 +2096,7 @@ namespace ArchiSteamFarm {
 
 		private string ResponseHelp(ulong steamID) {
 			if (steamID != 0) {
-				return IsMaster(steamID) ? FormatBotResponse("https://github.com/" + SharedInfo.GithubRepo + "/wiki/Commands") : null;
+				return IsOperator(steamID) ? FormatBotResponse("https://github.com/" + SharedInfo.GithubRepo + "/wiki/Commands") : null;
 			}
 
 			ArchiLogger.LogNullError(nameof(steamID));
@@ -2280,7 +2289,7 @@ namespace ArchiSteamFarm {
 				return null;
 			}
 
-			if (!IsMaster(steamID)) {
+			if (!IsOperator(steamID)) {
 				return null;
 			}
 
@@ -2566,7 +2575,7 @@ namespace ArchiSteamFarm {
 				return null;
 			}
 
-			if (!IsMaster(steamID)) {
+			if (!IsOperator(steamID)) {
 				return null;
 			}
 
@@ -2904,7 +2913,7 @@ namespace ArchiSteamFarm {
 				return null;
 			}
 
-			if (!IsMaster(steamID)) {
+			if (!IsOperator(steamID)) {
 				return null;
 			}
 
@@ -3033,7 +3042,7 @@ namespace ArchiSteamFarm {
 
 		private string ResponseUnknown(ulong steamID) {
 			if (steamID != 0) {
-				return IsMaster(steamID) ? FormatBotResponse(Strings.UnknownCommand) : null;
+				return IsOperator(steamID) ? FormatBotResponse(Strings.UnknownCommand) : null;
 			}
 
 			ArchiLogger.LogNullError(nameof(steamID));
@@ -3056,7 +3065,7 @@ namespace ArchiSteamFarm {
 
 		private string ResponseVersion(ulong steamID) {
 			if (steamID != 0) {
-				return IsMaster(steamID) ? FormatBotResponse(string.Format(Strings.BotVersion, SharedInfo.ASF, SharedInfo.Version)) : null;
+				return IsOperator(steamID) ? FormatBotResponse(string.Format(Strings.BotVersion, SharedInfo.ASF, SharedInfo.Version)) : null;
 			}
 
 			ArchiLogger.LogNullError(nameof(steamID));

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -100,7 +100,7 @@ namespace ArchiSteamFarm {
 		[JsonProperty(Required = Required.DisallowNull)]
 		internal readonly ulong SteamMasterID = 0;
 
-		[JsonProperty]
+		[JsonProperty(Required = Required.DisallowNull)]
 		internal readonly ulong SteamOperatorID = 0;
 
 		[JsonProperty]

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -101,6 +101,9 @@ namespace ArchiSteamFarm {
 		internal readonly ulong SteamMasterID = 0;
 
 		[JsonProperty]
+		internal readonly ulong SteamOperatorID = 0;
+
+		[JsonProperty]
 		internal readonly string SteamTradeToken = null;
 
 		[JsonProperty(Required = Required.DisallowNull)]

--- a/ArchiSteamFarm/config/example.json
+++ b/ArchiSteamFarm/config/example.json
@@ -24,6 +24,7 @@
 	"SteamLogin": null,
 	"SteamMasterClanID": 0,
 	"SteamMasterID": 0,
+	"SteamOperatorID": 0,
 	"SteamParentalPIN": "0",
 	"SteamPassword": null,
 	"SteamTradeToken": null,

--- a/ConfigGenerator/BotConfig.cs
+++ b/ConfigGenerator/BotConfig.cs
@@ -117,6 +117,10 @@ namespace ConfigGenerator {
 		public ulong SteamMasterID { get; set; } = 0;
 
 		[LocalizedCategory("Access")]
+		[JsonProperty(Required = Required.DisallowNull)]
+		public ulong SteamOperatorID { get; set; } = 0;
+
+		[LocalizedCategory("Access")]
 		[JsonProperty]
 		public string SteamParentalPIN { get; set; } = "0";
 


### PR DESCRIPTION
Sometimes i need to get keys from other sources that WCF and master/owner users. For example - i have a freind of mine that sometimes finds a cheap keys. I would like to let him to upload them into my ASF.

Currently, being a op, allows you to use these commands:

- `!addlicense`
- `!redeem`
- `!owns`
- `!status`
- `!version`
- `!help`

Also bot will accept freind request from op.

These commands would be sufficient to nicely check and upload new games. Basicaly, i can just make my freind op, or create a new steam account and make it op - it will allow  anyone who knows its login and password become op.