### PR TITLE
Allow cross site access, (for example via javascript) for IPC

### DIFF
--- a/ArchiSteamFarm/IPC.cs
+++ b/ArchiSteamFarm/IPC.cs
@@ -121,7 +121,7 @@ namespace ArchiSteamFarm {
 									string response = await bot.Response(Program.GlobalConfig.SteamOwnerID, command).ConfigureAwait(false);
 
 									ASF.ArchiLogger.LogGenericInfo(string.Format(Strings.IPCAnswered, command, response));
-									context.Response.AppendHeader("Access-Control-Allow-Origin", "null");
+									
 									await context.Response.WriteAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
 									break;
 							}
@@ -166,6 +166,8 @@ namespace ArchiSteamFarm {
 				if (response.StatusCode != (ushort) statusCode) {
 					response.StatusCode = (ushort) statusCode;
 				}
+
+				response.AppendHeader("Access-Control-Allow-Origin", "null");
 
 				Encoding encoding = Encoding.UTF8;
 

--- a/ArchiSteamFarm/IPC.cs
+++ b/ArchiSteamFarm/IPC.cs
@@ -121,7 +121,7 @@ namespace ArchiSteamFarm {
 									string response = await bot.Response(Program.GlobalConfig.SteamOwnerID, command).ConfigureAwait(false);
 
 									ASF.ArchiLogger.LogGenericInfo(string.Format(Strings.IPCAnswered, command, response));
-
+									context.Response.AppendHeader("Access-Control-Allow-Origin", "null");
 									await context.Response.WriteAsync(HttpStatusCode.OK, response).ConfigureAwait(false);
 									break;
 							}


### PR DESCRIPTION
Hi,

when sending an IPC command from within javascript (eg from a local file) this is required.

"null" should only fit to all scripts executed inside of "file///..." or other "no-domain" stuff and therefore (in contrast to "*") a hostile takeover via malicious javascript should not be possible.
But I am no expert for javascript-security, so if in doubt make it into a config property.

(Or if in doubt discard it. Then only internal requests and parsing the result are not possible. GUI should still be doable by opening a new window and closing it again.)

Why?

For a browser GUI, that would be easily customizable even for people that can not compile, is cross platform as long as you own a browser and would be easier to understand (since way less code) if people want to look into it ;->

 A minimal example is included.
If you do not place the file inside the ASF folder (same dir, where "log.txt" resides) remove the "updateLog" function and corresponding "setInterval" call.

Lol, I could append docx but not html?...

Oh, and of course this file is only meant for local usage. 

```html
<head>
<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
  <style type='text/css'>
   textarea {
    white-space: pre;
    overflow:    scroll;
    overflow-y:  scroll;
    overflow-x:  scroll;
    overflow:    -moz-scrollbars-horizontal;
   }
  </style>
</head>

<body>
<input id="commandInput" size="120" /><button onclick='sendCommand();'>Send</button> 
<textarea id="commandReply" cols="150" rows="10" readonly></textarea>
<textarea id="consoleOut" cols="150" rows="30" readonly></textarea>

<script>
var textarea = document.getElementById('consoleOut');
function updateLog(){
	$("#consoleOut").load("log.txt");
	textarea.scrollTop = textarea.scrollHeight;
}
setInterval(updateLog, 5000);

function sendCommand(){
	$.get("http://127.0.0.1:1242/IPC/?command=" + document.getElementById('commandInput').value,function(data) {
			document.getElementById('commandReply').value = data;
		});
}
</script>
</body>
```
