### PR TITLE
Config Generator improvements

### DIFF
--- a/WebConfigGenerator/package-lock.json
+++ b/WebConfigGenerator/package-lock.json
@@ -6655,6 +6655,12 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -6674,12 +6680,6 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
-    },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",

--- a/WebConfigGenerator/src/components/ASFConfig.vue
+++ b/WebConfigGenerator/src/components/ASFConfig.vue
@@ -24,17 +24,17 @@
 </template>
 
 <script>
-    import { each } from "lodash";
-    import Config from "./mixin/Config.vue";
-    import Schema from "../schema";
+    import { each } from 'lodash';
+    import Config from './mixin/Config.vue';
+    import Schema from '../schema';
 
     export default {
         name: 'ASFConfig',
-        mixins: [ Config ],
+        mixins: [Config],
         data() {
             return {
-                versions: [ 'Latest', 'V3.0.1.6-V3.0.3.6' ]
-            }
+                versions: ['Latest', 'V3.0.1.6-V3.0.3.6']
+            };
         },
         computed: {
             schema() {
@@ -61,11 +61,11 @@
                 }
 
                 each(model, (value, key) => {
-                    if (typeof value === 'string' && value === "") delete model[key];
+                    if (typeof value === 'string' && value === '') delete model[key];
                 });
 
                 return model;
             }
         }
-    }
+    };
 </script>

--- a/WebConfigGenerator/src/components/ASFConfig.vue
+++ b/WebConfigGenerator/src/components/ASFConfig.vue
@@ -26,35 +26,12 @@
 <script>
     import { each } from 'lodash';
     import Config from './mixin/Config.vue';
-    import Schema from '../schema';
 
     export default {
         name: 'ASFConfig',
         mixins: [Config],
-        data() {
-            return {
-                versions: ['Latest', 'V3.0.1.6-V3.0.3.6']
-            };
-        },
-        computed: {
-            schema() {
-                if (Schema[this.selectedVersion]) {
-                    return Schema[this.selectedVersion].asf;
-                }
-
-                return Schema.Latest.asf;
-            }
-        },
+        data() { return { type: 'asf', filename: 'ASF.json' }; },
         methods: {
-            downloadJSON() {
-                if (!this.validateForm()) return;
-
-                const json = this.processModelToJSON(this.model);
-                const text = JSON.stringify(json);
-                const filename = 'ASF.json';
-
-                this.downloadText(text, filename);
-            },
             processModelToJSON(model) {
                 if (model.Blacklist && model.Blacklist.length) {
                     model.Blacklist = model.Blacklist.map(item => parseInt(item, 10)).filter(item => !isNaN(item) && item > 0);

--- a/WebConfigGenerator/src/components/BotConfig.vue
+++ b/WebConfigGenerator/src/components/BotConfig.vue
@@ -24,17 +24,17 @@
 </template>
 
 <script>
-    import { each } from "lodash";
-    import Config from "./mixin/Config.vue";
-    import Schema from "../schema";
+    import { each } from 'lodash';
+    import Config from './mixin/Config.vue';
+    import Schema from '../schema';
 
     export default {
         name: 'BotConfig',
-        mixins: [ Config ],
+        mixins: [Config],
         data() {
             return {
-                versions: [ 'Latest', 'V3.0.1.6-V3.0.3.6' ]
-            }
+                versions: ['Latest', 'V3.0.1.6-V3.0.3.6']
+            };
         },
         computed: {
             schema() {
@@ -61,11 +61,11 @@
                 }
 
                 each(model, (value, key) => {
-                    if (typeof value === 'string' && value === "") delete model[key];
+                    if (typeof value === 'string' && value === '') delete model[key];
                 });
 
                 return model;
             }
         }
-    }
+    };
 </script>

--- a/WebConfigGenerator/src/components/BotConfig.vue
+++ b/WebConfigGenerator/src/components/BotConfig.vue
@@ -26,35 +26,13 @@
 <script>
     import { each } from 'lodash';
     import Config from './mixin/Config.vue';
-    import Schema from '../schema';
 
     export default {
         name: 'BotConfig',
         mixins: [Config],
-        data() {
-            return {
-                versions: ['Latest', 'V3.0.1.6-V3.0.3.6']
-            };
-        },
-        computed: {
-            schema() {
-                if (Schema[this.selectedVersion]) {
-                    return Schema[this.selectedVersion].bot;
-                }
-
-                return Schema.Latest.bot;
-            }
-        },
+        data() { return { type: 'bot' }; },
+        computed: { filename() { return `${this.model.name}.json`; } },
         methods: {
-            downloadJSON() {
-                if (!this.validateForm()) return;
-
-                const json = this.processModelToJSON(this.model);
-                const text = JSON.stringify(json);
-                const filename = `${this.model.name}.json`;
-
-                this.downloadText(text, filename);
-            },
             processModelToJSON(model) {
                 if (model.GamesPlayedWhileIdle && model.GamesPlayedWhileIdle.length) {
                     model.GamesPlayedWhileIdle = model.GamesPlayedWhileIdle.map(value => parseInt(value, 10)).filter(value => !isNaN(value) && value > 0);

--- a/WebConfigGenerator/src/components/Home.vue
+++ b/WebConfigGenerator/src/components/Home.vue
@@ -1,20 +1,14 @@
 <template>
     <div class="home">
-        <p class="text-justify" v-html="$t('home.topic')"> </p>
+        <p class="text-justify" v-html="$t('home.topic')"></p>
     </div>
 </template>
 
 <script>
-    export default {
-
-    }
+    export default {};
 </script>
 
 <style>
-    .home {
-
-    }
-
     .text-justify {
         text-align: justify;
     }

--- a/WebConfigGenerator/src/components/fields/CheckboxGroup.vue
+++ b/WebConfigGenerator/src/components/fields/CheckboxGroup.vue
@@ -14,5 +14,5 @@
     export default {
         mixins: [Input],
         name: 'CheckboxGroup'
-    }
+    };
 </script>

--- a/WebConfigGenerator/src/components/fields/InputCheckbox.vue
+++ b/WebConfigGenerator/src/components/fields/InputCheckbox.vue
@@ -15,7 +15,7 @@
     export default {
         mixins: [Input],
         name: 'InputCheckbox'
-    }
+    };
 </script>
 
 <style lang="scss">

--- a/WebConfigGenerator/src/components/fields/InputFlag.vue
+++ b/WebConfigGenerator/src/components/fields/InputFlag.vue
@@ -37,7 +37,7 @@
             return {
                 items: [], // Vue doesn't work well with Sets...
                 flagValue: this.schema.defaultValue
-            }
+            };
         },
         methods: {
             addElement() {
@@ -54,13 +54,13 @@
                 if (!options) return toResolve;
 
                 options.forEach(({ value, name }) => {
-                    if (toResolve === value) toResolve = name
+                    if (toResolve === value) toResolve = name;
                 });
 
                 return toResolve;
             }
         }
-    }
+    };
 </script>
 
 <style lang="scss">

--- a/WebConfigGenerator/src/components/fields/InputMap.vue
+++ b/WebConfigGenerator/src/components/fields/InputMap.vue
@@ -33,7 +33,8 @@
         </div>
 
         <p class="label-list">
-            <span v-for="(value, key) in items" class="label outline" @click.prevent="removeElement(key)">{{ resolveOption(key, schema.keys) }} => {{ resolveOption(value, schema.values) }}</span>
+            <span v-for="(value, key) in items" class="label outline" @click.prevent="removeElement(key)">{{ resolveOption(key, schema.keys)
+                }} => {{ resolveOption(value, schema.values) }}</span>
         </p>
     </div>
 </template>
@@ -66,11 +67,11 @@
                 items: {}, // Vue doesn't work well with Maps...
                 mapKey: this.schema.defaultKey,
                 mapValue: this.schema.defaultValue
-            }
+            };
         },
         methods: {
             addElement() {
-                if (!this.mapValue && this.mapValue !== 0 || !this.mapKey && this.mapKey !== 0)  return;
+                if (!this.mapValue && this.mapValue !== 0 || !this.mapKey && this.mapKey !== 0) return;
 
                 if (this.hasErrors()) return;
 
@@ -87,7 +88,7 @@
                 if (!options) return toResolve;
 
                 options.forEach(({ value, name }) => {
-                    if (toResolve === value) toResolve = name
+                    if (toResolve === value) toResolve = name;
                 });
 
                 return toResolve;
@@ -107,7 +108,7 @@
                 return true;
             }
         }
-    }
+    };
 </script>
 
 <style lang="scss">

--- a/WebConfigGenerator/src/components/fields/InputNumber.vue
+++ b/WebConfigGenerator/src/components/fields/InputNumber.vue
@@ -5,7 +5,8 @@
             <span v-if="schema.required" class="req">*</span>
             <span v-if="schema.description" class="desc">{{ schema.description }}</span>
         </label>
-        <input type="number" :name="schema.field" :id="schema.field" :placeholder="schema.placeholder" :required="schema.required" :class="{ error: invalid }" v-model.number="value">
+        <input type="number" :name="schema.field" :id="schema.field" :placeholder="schema.placeholder" :required="schema.required" :class="{ error: invalid }"
+               v-model.number="value">
         <span v-if="invalid" class="error">{{ errors.join(' ') }}</span>
     </div>
 </template>
@@ -27,5 +28,5 @@
                 return this.errors.length !== 0;
             }
         }
-    }
+    };
 </script>

--- a/WebConfigGenerator/src/components/fields/InputPassword.vue
+++ b/WebConfigGenerator/src/components/fields/InputPassword.vue
@@ -27,5 +27,5 @@
                 return this.errors.length !== 0;
             }
         }
-    }
+    };
 </script>

--- a/WebConfigGenerator/src/components/fields/InputSelect.vue
+++ b/WebConfigGenerator/src/components/fields/InputSelect.vue
@@ -17,5 +17,5 @@
     export default {
         mixins: [Input],
         name: 'InputSelect'
-    }
+    };
 </script>

--- a/WebConfigGenerator/src/components/fields/InputSet.vue
+++ b/WebConfigGenerator/src/components/fields/InputSet.vue
@@ -9,7 +9,8 @@
         <div class="row gutters">
             <div class="col col-10">
                 <div class="form-input">
-                    <input v-if="!schema.values" type="text" :name="schema.field" :placeholder="schema.placeholder" :id="schema.field" class="set-value" :class="{ error: invalid }" v-model="setValue">
+                    <input v-if="!schema.values" type="text" :name="schema.field" :placeholder="schema.placeholder" :id="schema.field" class="set-value" :class="{ error: invalid }"
+                           v-model="setValue">
                     <span v-if="!schema.values && invalid" class="error">{{ errors.join(' ') }}</span>
                     <select v-if="schema.values" v-model="setValue" :id="schema.field">
                         <option v-for="val in schema.values" :value="val.value">{{ $t(val.name) }}</option>
@@ -48,7 +49,7 @@
             return {
                 items: [], // Vue doesn't work well with Sets...
                 setValue: this.schema.defaultValue
-            }
+            };
         },
         methods: {
             addElement() {
@@ -66,7 +67,7 @@
                 if (!options) return toResolve;
 
                 options.forEach(({ value, name }) => {
-                    if (toResolve === value) toResolve = name
+                    if (toResolve === value) toResolve = name;
                 });
 
                 return toResolve;
@@ -84,7 +85,7 @@
                 return true;
             }
         }
-    }
+    };
 </script>
 
 <style lang="scss">

--- a/WebConfigGenerator/src/components/fields/InputText.vue
+++ b/WebConfigGenerator/src/components/fields/InputText.vue
@@ -27,5 +27,5 @@
                 return this.errors.length !== 0;
             }
         }
-    }
+    };
 </script>

--- a/WebConfigGenerator/src/components/mixin/Config.vue
+++ b/WebConfigGenerator/src/components/mixin/Config.vue
@@ -1,21 +1,21 @@
 <script>
-    import { each } from "lodash";
+    import { each } from 'lodash';
 
     const fieldComponents = {};
-    const fields = require.context("../fields", false, /^\.\/([\w-_]+)\.vue$/);
+    const fields = require.context('../fields', false, /^\.\/([\w-_]+)\.vue$/);
 
     each(fields.keys(), key => {
-        const name = key.replace(/^\.\//, "").replace(/\.vue/, "");
+        const name = key.replace(/^\.\//, '').replace(/\.vue/, '');
         fieldComponents[name] = fields(key);
     });
 
     export default {
-        data () {
+        data() {
             return {
                 model: {},
                 displayAdvanced: false,
                 selectedVersion: 'Latest'
-            }
+            };
         },
         methods: {
             updateModel(value, field) {
@@ -49,7 +49,7 @@
             }
         },
         components: fieldComponents
-    }
+    };
 </script>
 
 <style lang="scss">

--- a/WebConfigGenerator/src/components/mixin/Config.vue
+++ b/WebConfigGenerator/src/components/mixin/Config.vue
@@ -1,6 +1,8 @@
 <script>
     import { each } from 'lodash';
 
+    import schema from '../../schema';
+
     const fieldComponents = {};
     const fields = require.context('../fields', false, /^\.\/([\w-_]+)\.vue$/);
 
@@ -11,15 +13,35 @@
 
     export default {
         data() {
+            const versions = [];
+            for (const version in schema) versions.push(version);
+
+            const selectedVersion = sessionStorage.getItem('selectedVersion') || versions[0];
+
             return {
                 model: {},
                 displayAdvanced: false,
-                selectedVersion: 'Latest'
+                selectedVersion,
+                versions,
+                type: ''
             };
+        },
+        computed: {
+            schema() {
+                return schema[this.selectedVersion][this.type] || {};
+            }
         },
         methods: {
             updateModel(value, field) {
                 this.model[field] = value;
+            },
+            downloadJSON() {
+                if (!this.validateForm()) return;
+
+                const json = this.processModelToJSON(this.model);
+                const text = JSON.stringify(json);
+
+                this.downloadText(text, this.filename);
             },
             downloadText(text, filename) {
                 const element = document.createElement('a');
@@ -46,6 +68,14 @@
                 each(fields, field => { field.classList.add('shake'); });
                 this.shakeTimeout = setTimeout(() => { each(fields, field => { field.classList.remove('shake'); }); }, 500);
                 return false;
+            },
+            processModelToJSON(model) {
+                return model;
+            }
+        },
+        watch: {
+            selectedVersion(version) {
+                sessionStorage.setItem('selectedVersion', version);
             }
         },
         components: fieldComponents

--- a/WebConfigGenerator/src/components/mixin/Input.vue
+++ b/WebConfigGenerator/src/components/mixin/Input.vue
@@ -1,15 +1,15 @@
 <script>
-    import Validators from "../../validators";
+    import Validators from '../../validators';
 
     export default {
-        props: [ 'schema' ],
+        props: ['schema'],
         watch: {
             value() {
                 this.$emit('update', this.value, this.schema.field);
             }
         },
         data() {
-            return { value: this.schema.defaultValue }
+            return { value: this.schema.defaultValue };
         },
         methods: {
             validate(value, validator) {
@@ -22,5 +22,5 @@
                 return validator(value, this.schema);
             }
         }
-    }
+    };
 </script>

--- a/WebConfigGenerator/src/i18n.js
+++ b/WebConfigGenerator/src/i18n.js
@@ -1,54 +1,54 @@
-const defaultLocale = "strings";
+const defaultLocale = 'strings';
 
 export default {
-  getLanguage() {
-    // Chrome and Firefox 32+
-    return navigator.languages || [
-      navigator.language ||
-      navigator.browserLanguage
-    ]
-  },
-  loadLocale(locale) {
-    return require(`./locale/${locale}`);
-  },
-  getSplitedLanguage(language) {
-    if (language.indexOf("-") != -1) {
-      return language.substring(0, language.indexOf("-"));
-    }
-    return language
-  },
-  getLocale() {
-    const messages = {};
-
-    let locale = defaultLocale;
-
-    for (const lang of this.getLanguage()) {
-      try {
-        locale = lang;
-        messages[locale] = this.loadLocale(locale);
-        // First match
-        break;
-      // If import error will throw error
-      } catch (e) {
-        locale = defaultLocale; 
-      }
-    }
-
-    // match head language when first match is failure
-    if (locale === defaultLocale) {
-      for (const lang of this.getLanguage()) {
-        const splitedLang = this.getSplitedLanguage(lang);
-        try {
-          locale = splitedLang;
-          messages[locale] = this.loadLocale(locale);
-          break;
-        } catch (e) {
-          locale = defaultLocale;
+    getLanguage() {
+        // Chrome and Firefox 32+
+        return navigator.languages || [
+            navigator.language ||
+            navigator.browserLanguage
+        ];
+    },
+    loadLocale(locale) {
+        return require(`./locale/${locale}`);
+    },
+    getSplitedLanguage(language) {
+        if (language.indexOf('-') != -1) {
+            return language.substring(0, language.indexOf('-'));
         }
-      }
+        return language;
+    },
+    getLocale() {
+        const messages = {};
+
+        let locale = defaultLocale;
+
+        for (const lang of this.getLanguage()) {
+            try {
+                locale = lang;
+                messages[locale] = this.loadLocale(locale);
+                // First match
+                break;
+                // If import error will throw error
+            } catch (e) {
+                locale = defaultLocale;
+            }
+        }
+
+        // match head language when first match is failure
+        if (locale === defaultLocale) {
+            for (const lang of this.getLanguage()) {
+                const splitedLang = this.getSplitedLanguage(lang);
+                try {
+                    locale = splitedLang;
+                    messages[locale] = this.loadLocale(locale);
+                    break;
+                } catch (e) {
+                    locale = defaultLocale;
+                }
+            }
+        }
+        messages[defaultLocale] = this.loadLocale(defaultLocale);
+
+        return { messages, locale };
     }
-    messages[defaultLocale] = this.loadLocale(defaultLocale);
-       
-    return { messages, locale };
-  }
-}
+};

--- a/WebConfigGenerator/src/i18n.js
+++ b/WebConfigGenerator/src/i18n.js
@@ -1,54 +1,46 @@
 const defaultLocale = 'strings';
+const nameRegex = /\.\/(\S+)\.json/i;
 
-export default {
-    getLanguage() {
-        // Chrome and Firefox 32+
-        return navigator.languages || [
-            navigator.language ||
-            navigator.browserLanguage
-        ];
-    },
-    loadLocale(locale) {
-        return require(`./locale/${locale}`);
-    },
-    getSplitedLanguage(language) {
-        if (language.indexOf('-') != -1) {
-            return language.substring(0, language.indexOf('-'));
-        }
-        return language;
-    },
-    getLocale() {
-        const messages = {};
+function getLocale(validLocales) {
+    const language = navigator.language; // If the browser doesn't support this, it will not support other page elements as well
+    if (!language) return defaultLocale; // If the browser doesn't provide the language - return default locale
+    if (language.length !== 2) return validLocales.includes(language) ? language : defaultLocale; // If the language is in `xx-XX` format, check if it's valid
+    if (validLocales.includes(`${language}-${language.toUpperCase()}`)) return `${language}-${language.toUpperCase()}`; // If the language is two letter code, check if corresponding 5 letter code is a valid locale
 
-        let locale = defaultLocale;
+    const languageRegex = new RegExp(`${language}\-\\\S\\\S`); // Create a regex to match `xx-**` where `*` is a wildcard
 
-        for (const lang of this.getLanguage()) {
-            try {
-                locale = lang;
-                messages[locale] = this.loadLocale(locale);
-                // First match
-                break;
-                // If import error will throw error
-            } catch (e) {
-                locale = defaultLocale;
-            }
-        }
-
-        // match head language when first match is failure
-        if (locale === defaultLocale) {
-            for (const lang of this.getLanguage()) {
-                const splitedLang = this.getSplitedLanguage(lang);
-                try {
-                    locale = splitedLang;
-                    messages[locale] = this.loadLocale(locale);
-                    break;
-                } catch (e) {
-                    locale = defaultLocale;
-                }
-            }
-        }
-        messages[defaultLocale] = this.loadLocale(defaultLocale);
-
-        return { messages, locale };
+    for (const validLocale of validLocales) {
+        if (languageRegex.test(validLocale)) return validLocale; // Check if the locale matches the regex, if so, return it
     }
-};
+
+    return defaultLocale; // If no match found, return default locale
+}
+
+function loadLocales() {
+    const locales = {};
+    const defaultLanguageFile = `./${defaultLocale}.json`;
+    const languages = require.context('./locale/', false, /\.json/);
+
+    locales[defaultLocale] = languages(defaultLanguageFile);
+
+    for (const lang of languages.keys()) {
+        if (lang === defaultLanguageFile) continue; // Already loaded.
+
+        const languageName = lang.match(nameRegex)[1];
+        const language = languages(lang);
+
+        for (const key in language) {
+            if (!language.hasOwnProperty(key)) continue;
+            if (language[key] === '') language[key] = locales[defaultLocale][key];
+        }
+
+        locales[languageName] = language;
+    }
+
+    return locales;
+}
+
+const messages = loadLocales();
+const locale = getLocale(Object.keys(messages));
+
+export default { messages, locale };

--- a/WebConfigGenerator/src/main.js
+++ b/WebConfigGenerator/src/main.js
@@ -1,31 +1,32 @@
 // The Vue build version to load with the `import` command
 // (runtime-only or standalone) has been set in webpack.base.conf with an alias.
-import Vue from 'vue'
-import VueI18n from 'vue-i18n'
-import App from './App'
-import router from './router'
-import appi18n from './i18n.js'
+import Vue from 'vue';
+import VueI18n from 'vue-i18n';
 
-Vue.config.productionTip = false
+import App from './App.vue';
+import appi18n from './i18n.js';
+import router from './router';
+
+Vue.config.productionTip = false;
 
 Vue.use(VueI18n);
 
-const { locale, messages } = appi18n.getLocale()
+const { locale, messages } = appi18n.getLocale();
 
 const i18n = new VueI18n({
     locale,
-    messages,
-})
+    messages
+});
 
 /* eslint-disable no-new */
 new Vue({
-  el: '#app',
-  router,
-  i18n,
-  template: '<App/>',
-  components: { App }
-})
+    el: '#app',
+    router,
+    i18n,
+    template: '<App/>',
+    components: { App }
+});
 
-if('serviceWorker' in navigator) {
+if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('service-worker.js');
 }

--- a/WebConfigGenerator/src/main.js
+++ b/WebConfigGenerator/src/main.js
@@ -4,19 +4,16 @@ import Vue from 'vue';
 import VueI18n from 'vue-i18n';
 
 import App from './App.vue';
-import appi18n from './i18n.js';
+import i18nSettings from './i18n.js';
 import router from './router';
 
 Vue.config.productionTip = false;
 
 Vue.use(VueI18n);
 
-const { locale, messages } = appi18n.getLocale();
+console.log(i18nSettings);
 
-const i18n = new VueI18n({
-    locale,
-    messages
-});
+const i18n = new VueI18n(i18nSettings);
 
 /* eslint-disable no-new */
 new Vue({

--- a/WebConfigGenerator/src/router/index.js
+++ b/WebConfigGenerator/src/router/index.js
@@ -1,8 +1,9 @@
-import Vue from 'vue'
-import Router from 'vue-router'
-import Home from '@/components/Home'
-import ASFConfig from '@/components/ASFConfig'
-import BotConfig from '@/components/BotConfig'
+import ASFConfig from '@/components/ASFConfig';
+import BotConfig from '@/components/BotConfig';
+import Home from '@/components/Home';
+
+import Vue from 'vue';
+import Router from 'vue-router';
 
 Vue.use(Router);
 

--- a/WebConfigGenerator/src/schema.js
+++ b/WebConfigGenerator/src/schema.js
@@ -1,4 +1,4 @@
-import Validators from "./validators";
+import Validators from './validators';
 
 export default {
     'Latest': {
@@ -1002,4 +1002,4 @@ export default {
             }
         ]
     }
-}
+};

--- a/WebConfigGenerator/src/schema.js
+++ b/WebConfigGenerator/src/schema.js
@@ -1,7 +1,7 @@
 import Validators from './validators';
 
 export default {
-    'Latest': {
+    'V3.0.3.7+': {
         asf: [
             {
                 legend: 'schema.basic',

--- a/WebConfigGenerator/src/validators.js
+++ b/WebConfigGenerator/src/validators.js
@@ -1,7 +1,7 @@
-import { isNil, isString, isNumber, isArray } from "lodash";
+import { isArray, isNil, isNumber, isString } from 'lodash';
 
 function checkEmpty(value, required) {
-    if (isNil(value) || value === "") {
+    if (isNil(value) || value === '') {
         if (required) return ['Field required!'];
         else return [];
     }
@@ -26,7 +26,7 @@ function limitedNumber(min, max) {
         }
 
         return err;
-    }
+    };
 }
 
 function limitedString(min, max) {
@@ -44,7 +44,7 @@ function limitedString(min, max) {
         }
 
         return err;
-    }
+    };
 }
 
 export default {
@@ -110,4 +110,4 @@ export default {
     byte: limitedNumber(0, 255),
     ushort: limitedNumber(0, 65535),
     uint: limitedNumber(0, 4294967295)
-}
+};


### PR DESCRIPTION
Does the following from #659:

- [x] Find out why current localization code works properly only on IE.
- [x] We must add handling for empty localization strings generated by Crowdin.

Improves scheme loading mechanism as well. Now it's only required to add new model to `schema.js`, no need to change version list.