### PR TITLE
Remove bot name from config

### DIFF
--- a/WebConfigGenerator/src/components/BotConfig.vue
+++ b/WebConfigGenerator/src/components/BotConfig.vue
@@ -33,7 +33,9 @@
         data() { return { type: 'bot' }; },
         computed: { filename() { return `${this.model.name}.json`; } },
         methods: {
-            processModelToJSON(model) {
+            processModelToJSON(originalModel) {
+                const model = { ...originalModel }; // Need to clone that so we don't destroy `model.name`
+
                 if (model.GamesPlayedWhileIdle && model.GamesPlayedWhileIdle.length) {
                     model.GamesPlayedWhileIdle = model.GamesPlayedWhileIdle.map(value => parseInt(value, 10)).filter(value => !isNaN(value) && value > 0);
                 }
@@ -41,6 +43,8 @@
                 each(model, (value, key) => {
                     if (typeof value === 'string' && value === '') delete model[key];
                 });
+
+                if (model.name) delete model.name;
 
                 return model;
             }


### PR DESCRIPTION
`[14:49] Archi: Is it possible to exclude name from generated JSON? It's used only in config-gen as name of the bot, not needed in the config itself`

Fixed git my git config too 🎉 