### PR TITLE
.gitattributes update

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,17 +1,7 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+*     text=auto
+
+*.sh  text eol=lf
 
 # Custom for Visual Studio
-*.cs     diff=csharp
-
-# Standard to msysgit
-*.doc	 diff=astextplain
-*.DOC	 diff=astextplain
-*.docx diff=astextplain
-*.DOCX diff=astextplain
-*.dot  diff=astextplain
-*.DOT  diff=astextplain
-*.pdf  diff=astextplain
-*.PDF	 diff=astextplain
-*.rtf	 diff=astextplain
-*.RTF	 diff=astextplain
+*.cs  diff=csharp

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 # Auto detect text files and perform LF normalization
-*     text=auto
+* text=auto
 
-*.sh  text eol=lf
+*.sh text eol=lf
 
 # Custom for Visual Studio
-*.cs  diff=csharp
+*.cs diff=csharp


### PR DESCRIPTION
The file had a mix of spaces and tabs for indentation and references to the long-retired msysgit, for file types that aren't part of the repo.

I assumed with .NET Core it's no longer desired to have
`*.sln text eol=crlf`
`*.csproj text eol=crlf`
so I did not add these.