### PR TITLE
Add cross-set trading of unmarketable items

### DIFF
--- a/ArchiSteamFarm.Tests/Trading.cs
+++ b/ArchiSteamFarm.Tests/Trading.cs
@@ -200,7 +200,7 @@ namespace ArchiSteamFarm.Tests {
 				throw new ArgumentNullException(nameof(method));
 			}
 
-			return (bool) method.Invoke(null, new object[] { inventory, itemsToGive, itemsToReceive });
+			return (bool) method.Invoke(null, new object[] { inventory, itemsToGive, itemsToReceive, false });
 		}
 
 		private static Steam.Asset GenerateSteamCommunityItem(ulong classID, uint amount, uint realAppID, Steam.Asset.EType type) => new Steam.Asset(Steam.Asset.SteamAppID, Steam.Asset.SteamCommunityContextID, classID, amount, realAppID, type);

--- a/ArchiSteamFarm/ArchiWebHandler.cs
+++ b/ArchiSteamFarm/ArchiWebHandler.cs
@@ -1507,7 +1507,7 @@ namespace ArchiSteamFarm {
 
 				uint realAppID = appID;
 				Steam.Asset.EType type = Steam.Asset.EType.Unknown;
-                bool Marketable = false;
+                bool Marketable = true;
 
                 if (descriptions.TryGetValue(classID, out (uint AppID, Steam.Asset.EType Type, bool Marketable) description)) {
 					realAppID = description.AppID;

--- a/ArchiSteamFarm/BotConfig.cs
+++ b/ArchiSteamFarm/BotConfig.cs
@@ -343,7 +343,8 @@ namespace ArchiSteamFarm {
 			SteamTradeMatcher = 2,
 			MatchEverything = 4,
 			DontAcceptBotTrades = 8,
-			All = AcceptDonations | SteamTradeMatcher | MatchEverything | DontAcceptBotTrades
-		}
+            CrossSetUnmarketable = 16,
+			All = AcceptDonations | SteamTradeMatcher | MatchEverything | DontAcceptBotTrades | CrossSetUnmarketable
+        }
 	}
 }

--- a/ArchiSteamFarm/Json/Steam.cs
+++ b/ArchiSteamFarm/Json/Steam.cs
@@ -129,7 +129,7 @@ namespace ArchiSteamFarm.Json {
 			}
 
 			// Constructed from trades being received
-			internal Asset(uint appID, ulong contextID, ulong classID, uint amount, uint realAppID, EType type = EType.Unknown, bool marketable = false) {
+			internal Asset(uint appID, ulong contextID, ulong classID, uint amount, uint realAppID, EType type = EType.Unknown, bool marketable = true) {
 				if ((appID == 0) || (contextID == 0) || (classID == 0) || (amount == 0) || (realAppID == 0)) {
 					throw new ArgumentNullException(nameof(classID) + " || " + nameof(contextID) + " || " + nameof(classID) + " || " + nameof(amount) + " || " + nameof(realAppID));
 				}


### PR DESCRIPTION
### Intro
This feature adds a possibility to allow cross-set trading of unmarketable items.

### Purpose
This may be useful for the hosters of STM-like trade bots with huge inventory, and will help owners of unmarketable trading cards to finish their sets to craft badges.

### Description
This PR adds one extra option to `TradingPreferences` property, named `CrossSetUnmarketable` with value of `16`. This option works only with `SteamTradeMatcher` enabled, and does nothing without it. Also, it respects `MatchEverything` option, but treats all unmarketable items as belonging to same meta-game, thus if you have two cards from one set and giving one of them for the card from another set - it is considered good, and if you give away your only one card from one set and receiving a card from another set you already have - it's considered a bad trade.

### Testing
I tested this feature in different combinations, but trading module is rather complex, so I'm still worried if I missed something. I will be really grateful if you review it carefully before merging.

### Future improvements
It bot is participating in ASF STM listing it would be nice to send information about this option to asf server and show appropriate notice in ASF STM listing so that people knew that this bot can be helpful to complete unmarketable sets. This requires support on server side, so I did nothing about it in this PR, I leave it up to you if you decide that it is worth it.