### PR TITLE
IPC GUI inconsistency about disconnected bots info

### DIFF
--- a/ArchiSteamFarm/www/js/app.js
+++ b/ArchiSteamFarm/www/js/app.js
@@ -63,15 +63,16 @@ function displayBotStatus() {
                 if (KeepRunning === false) {
                     offline++;
                 } else {
-                    if (TimeRemaining === '00:00:00') {
-						if (SteamID === 0) {
-							disconnected++;
-						} else {
-							online++;
-						}
-                    } else {
-                        farming++;
-                    }
+			if (SteamID === 0) {
+				disconnected++;
+			} else {
+				if (TimeRemaining === '00:00:00') {
+					online++;
+				}
+				else {
+					farming++;
+				}
+			}
                 }
             }
 


### PR DESCRIPTION
A picture always explains better:
![](https://i.imgur.com/7fLE3GL.png)

Basically here two bots (`skaj08` and `skaj09`) have the red colored line above them, but the counter at the left menu shows 17 "green" and 1 "red", which doesn't looks really consistent.
This is really rare to happen though. Basically when a bot that **is farming** suddenly disconnects from Steam it won't have any effect on the counter at the left (as happened with `skaj09`). If the disconnected bot wasn't farming at the moment of the disconnection, then it will count (like the `skaj08` situation).

There's actually some inconsistency (at least in my opinion) in what the GUI considers a disconnected bot. In `bots.html` file, line 294, judging by the comment a bot is considered disconnected when in the IPC response `SteamID` is set to `0`. So any bot with `SteamID: 0` will have the red colored bar.
But checking the `app.js` file, lines 66-67, a bot is considered disconnected when `SteamID` is set to `0` **and** `TimeRemaining` is set to `00:00:00` (actually the disconnected bot is counted as a currently farming bot).

When a bot is farming and suddenly lost its connection to Steam, ASF IPC still reports the pending farming info, so TimeRemaining won't be zero: 
![](https://i.imgur.com/BncYJ4d.png)

I have just modified a bit the order of the comparisons on `app.js` file to make them more consistent with `bot.html` code. Now a bot will be counted as disconnected when `SteamID` is set to `0` and other factors won't interfere the disconnected status.