### PR TITLE
Return error for 2FA token generation action

### DIFF
--- a/ArchiSteamFarm/Steam/Interaction/Actions.cs
+++ b/ArchiSteamFarm/Steam/Interaction/Actions.cs
@@ -106,7 +106,9 @@ namespace ArchiSteamFarm.Steam.Interaction {
 
 			string? token = await Bot.BotDatabase.MobileAuthenticator.GenerateToken().ConfigureAwait(false);
 
-			return (true, token, Strings.Success);
+			bool success = !string.IsNullOrEmpty(token);
+
+			return (success, token, success ? Strings.Success : Strings.WarningFailed);
 		}
 
 		[PublicAPI]


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### Changed functionality

The `GenerateTwoFactorAuthenticationToken` now returns `false` as the success indicator, if the generated string is null or empty. This is accompanied by string `"Failed!"` instead of the previous `"Success!"`

## Additional info

Thank you for considering the inclusion of this merge request!
