### PR TITLE
Support thousands separator for parsing playtime

### DIFF
--- a/ArchiSteamFarm/Core/GeneratedRegexes.cs
+++ b/ArchiSteamFarm/Core/GeneratedRegexes.cs
@@ -25,7 +25,7 @@ namespace ArchiSteamFarm.Core;
 
 internal static partial class GeneratedRegexes {
 	private const string CdKeyPattern = @"^[0-9A-Z]{4,7}-[0-9A-Z]{4,7}-[0-9A-Z]{4,7}(?:(?:-[0-9A-Z]{4,7})?(?:-[0-9A-Z]{4,7}))?$";
-	private const string DecimalPattern = @"[0-9\.]+";
+	private const string DecimalPattern = @"[0-9\.,]+";
 	private const RegexOptions DefaultOptions = RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase;
 	private const string DigitsPattern = @"\d+";
 	private const string NonAsciiPattern = @"[^\u0000-\u007F]+";


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

None.

### Changed functionality

Fixed parsing of playtime for cases when game has a playtime of more than a thousand hours. In that case Steam will use a comma as a thousands separator, which will won't work with the current regex. Bug was introduced in [this commit](https://github.com/JustArchiNET/ArchiSteamFarm/commit/3cf4ef3466dcbbfb40009c7b64086d6cc4b5c7a3#diff-5935875031e6b263dbb32062b75b191f1c5a53493ef2cfb604c4f3c78b7e7788L627).

### Removed functionality

None.

## Additional info

Fun fact – this bug was discovered due to the failed overflow check (which is enabled in the debug build and throws an exception) somewhere deep in the codegen for the regex.
