### PR TITLE
Add ArchiSteamFarm.container podman quadlet

### DIFF
--- a/quadlets/.config/containers/systemd/ArchiSteamFarm@.container
+++ b/quadlets/.config/containers/systemd/ArchiSteamFarm@.container
@@ -21,7 +21,7 @@ ProtectKernelModules=yes
 ProtectKernelTunables=yes
 ProtectProc=invisible
 ProtectSystem=strict
-ReadWritePaths=/home/%i/ArchiSteamFarm /tmp
+ReadWritePaths=/home/%i/ArchiSteamFarm
 RemoveIPC=yes
 RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_UNIX
 RestrictNamespaces=yes
@@ -46,9 +46,7 @@ Image=docker.io/justarchi/archisteamfarm:latest
 #PublishPort=127.0.0.1:1242:1242
 #PublishPort=[::]:1242:1242
 # read-only attribute not sensible for config as ASF wants to chown. Also IPC may write to config 
-Volume=ArchiSteamFarm-config:/app/config:z
-#Volume=ArchiSteamFarm-logs:/app/logs:z
-#Volume=ArchiSteamFarm-plugins:/app/plugins:z
+Volume=/home/%i/ArchiSteamFarm:/app:z
 
 [Install]
 WantedBy=multi-user.target default.target


### PR DESCRIPTION
## Checklist

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

Adds a podman systemd unit file for ASF

### New functionality
Allows running ASF similar to a systemd service, but containerized in a container running as user. Use requires podman.

### Changed functionality

None.

### Removed functionality

None.

## Additional info

Requires podman (a daemonless docker alternative by Red Hat).

Use `stow -t ~ quadlets` in repository root to link to the appropriate location in `$HOME/.config/containers/systemd/` (by default)

`systemctl --user daemon-reload && systemctl --user start ArchiSteamFarm` to run the podman container

STDOUT is logged to the journal `journalctl --user -xeu ArchiSteamFarm`

More restrictive SELinux flags than the docker instructions have (`z` instead of `Z`). Otherwise identical to existing instructions for using docker per https://github.com/JustArchiNET/ArchiSteamFarm/wiki/Docker

Features optional auto-updating if tag in container registry gets updated. Most optional features are commented out in the file, targetting for sane defaults.


Please roast me:
<img width="1127" height="222" alt="grafik" src="https://github.com/user-attachments/assets/fe9d0403-98da-4271-b4c2-500225c876be" />

