### PR TITLE
fix: add workaround for .NET 10 SDK breaking change

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,6 +48,9 @@
 
 		<!-- Required for protobuf-net -->
 		<_DefaultValueAttributeSupport>true</_DefaultValueAttributeSupport>
+
+		<!-- TODO: Workaround for https://github.com/dotnet/runtime/issues/118630, evaluate if possible to remove later -->
+		<EnableConfigurationBindingGenerator>false</EnableConfigurationBindingGenerator>
 	</PropertyGroup>
 
 	<!-- Default configuration for fast-debugging builds -->


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

### New functionality

None.

### Changed functionality

Fixed trimmed build using .NET 10 SDK due to the breaking change (ref: https://github.com/dotnet/runtime/issues/118630)

### Removed functionality

None.

## Additional info

reaching consistency by ensuring that all possible user scenarios are broken is the true microsoft way