### PR TITLE
Fix NLog IPC Websocket over HTTP/2

### DIFF
--- a/ArchiSteamFarm/IPC/Controllers/Api/NLogController.cs
+++ b/ArchiSteamFarm/IPC/Controllers/Api/NLogController.cs
@@ -87,7 +87,6 @@ public sealed class NLogController : ArchiController {
 
 	[EndpointDescription("This API endpoint requires a websocket connection")]
 	[EndpointSummary("Fetches ASF log in realtime")]
-	[HttpGet]
 	[ProducesResponseType<IEnumerable<GenericResponse<string>>>((int) HttpStatusCode.OK)]
 	[ProducesResponseType<GenericResponse>((int) HttpStatusCode.BadRequest)]
 	public async Task<ActionResult> Get() {


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [ ] I have added tests to cover my changes, wherever they are necessary.
- [x] All new and existing tests pass.

## Changes

This fixes an issue I encountered with the log in the IPC API. When I switched the Kestrel config from HTTP to HTTPS, the live log stopped working in the web-ui. After significant troubleshooting, I discovered the issue was actually with using a WebSocket over HTTP/2 (which browsers only enable when using HTTPS). Microsoft's documentation for WebSockets in ASP.NET has [this note about HTTP/2 compatibility](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/websockets?view=aspnetcore-8.0#add-http2-websockets-support-for-existing-controllers):

> .NET 7 introduced WebSockets over HTTP/2 support for Kestrel, the SignalR JavaScript client, and SignalR with Blazor WebAssembly. HTTP/2 WebSockets use CONNECT requests rather than GET. If you previously used `[HttpGet("/path")]` on your controller action method for Websocket requests, update it to use `[Route("/path")]` instead.

The `/Api/NLog` had a `[HttpGet]` attribute, which was breaking compatibility with HTTP/2. Since the class has the `Route` attribute, I was able to simply remove the `HttpGet` attribute to get it working with HTTP/2. Since this function already has an explicit check for whether the request is a WebSocket, this shouldn't meaningfully impact the correctness of this route.

## Additional info

I saw the checklist includes an entry for adding a test for the change. While a test for this would probably be useful to have, I don't see any existing tests for the IPC API, and I'm not sure how to implement one that isn't just an integration test (i.e. spinning up a full ASF server and sending requests). I think this should be fine to merge without a test, but I left the checkbox unchecked for now.
