### PR TITLE
Add logging on background redeemer

### DIFF
--- a/ArchiSteamFarm/Localization/Strings.resx
+++ b/ArchiSteamFarm/Localization/Strings.resx
@@ -807,4 +807,7 @@ Process uptime: {1}</value>
 		<value>Decryption of {0} database component has failed. This can be OK if you've just changed your bot's {1}, you should no longer observe this warning on the next run then. Otherwise, you should investigate and find out the exact reason for failure.</value>
 		<comment>{0} will be replaced by bot database component's name (string), {1} will be replaced by bot config component's name (string).</comment>
 	</data>
+	<data name="WarningNoValidKeysFound" xml:space="preserve">
+		<value>No valid keys were found in your .keys file for redemption. Please ensure your keys are in the correct format.</value>
+	</data>
 </root>

--- a/ArchiSteamFarm/Steam/Bot.cs
+++ b/ArchiSteamFarm/Steam/Bot.cs
@@ -1495,7 +1495,11 @@ public sealed class Bot : IAsyncDisposable, IDisposable {
 
 				if (gamesToRedeemInBackground.Count > 0) {
 					AddGamesToRedeemInBackground(gamesToRedeemInBackground);
+				} else {
+					ArchiLogger.LogGenericWarning(Strings.WarningNoValidKeysFound);
 				}
+			} else {
+				ArchiLogger.LogGenericError(Strings.FormatErrorIsEmpty(filePath));
 			}
 
 			File.Delete(filePath);


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] I read and understood the **[Contributing Guidelines](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md)**.
- [x] This is not a **[duplicate](https://github.com/JustArchiNET/ArchiSteamFarm/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] My code follows the **[code style](https://github.com/JustArchiNET/ArchiSteamFarm/blob/main/.github/CONTRIBUTING.md#code-style)** of this project.
- [x] I have added tests to cover my changes, wherever they are necessary.
- [ ] All new and existing tests pass.

## Changes

Added logging for background redeemer if no keys are found in a pasted .keys file or if the file was empty. 

### New functionality

<!-- Please describe below, what new functionality was added. -->

```
2026-02-05 03:47:54|ArchiSteamFarm-96380|WARN|Bot-X|ImportKeysToRedeem() No valid keys were found in your .keys file for redemption. Please ensure your keys are in the correct format.
2026-02-05 03:48:37|ArchiSteamFarm-96380|ERROR|Bot-X|ImportKeysToRedeem() config/Bot-kn16htbot.keys is empty!
```

## Additional info

<!-- Everything else you consider note-worthy that we didn't ask for. -->
Right now an empty .keys file or a file with the wrong formatting is silently discarded. (example: KEY TAB GAMENAME)